### PR TITLE
クイズモードのページ構成を変更する

### DIFF
--- a/app/controllers/quiz_controller.rb
+++ b/app/controllers/quiz_controller.rb
@@ -6,15 +6,15 @@ class QuizController < ApplicationController
 
   # POST /quiz
   def answer
-    question = Question.find(quiz_params[:question_id])
+    @question = Question.find(quiz_params[:question_id])
 
     respond_to do |format|
-      if question.is_correct?(quiz_params[:answer])
-        flash[:success] = 'Correct'
-        format.html { redirect_to quiz_url }
+      if @question.is_correct?(quiz_params[:answer])
+        flash.now[:success] = 'Correct'
+        format.html { render :answer }
       else
-        flash[:alert] = 'Incorrect'
-        format.html { redirect_to quiz_url }
+        flash.now[:alert] = 'Incorrect'
+        format.html { render :answer }
       end
     end
   end

--- a/app/views/quiz/answer.html.erb
+++ b/app/views/quiz/answer.html.erb
@@ -1,0 +1,19 @@
+<h1>Quiz</h1>
+
+<%= render 'shared/flash' %>
+
+<h2>Qustion</h2>
+
+<div class="mb-3">
+  <%== @question.content_html %>
+</div>
+
+<h2>Answer</h2>
+
+<div class="mb-3">
+  <%== @question.answer.content %>
+</div>
+
+<div class="mb-3">
+  <%= link_to 'Next Quiz', quiz_path, {:class => 'btn btn-primary'} %>
+</div>

--- a/spec/controllers/quiz_controller_spec.rb
+++ b/spec/controllers/quiz_controller_spec.rb
@@ -29,14 +29,15 @@ describe QuizController do
       }
     end
 
-    it 'redirect to :question template' do
+    it 'renders :answer template' do
       post :answer, params: { quiz: quiz_attributes }, session: {}
-      expect(response).to redirect_to(quiz_path)
+      expect(response).to render_template :answer
     end
 
     it 'message should be include in flash[:success] with quiz correct' do
       post :answer, params: { quiz: quiz_attributes }, session: {}
       expect(flash[:success]).to eq 'Correct'
+      expect(flash[:alert]).to eq nil
     end
 
     it 'message should be include in flash[:alert] with quiz incorrect' do
@@ -47,6 +48,7 @@ describe QuizController do
         }
       }, session: {}
       expect(flash[:alert]).to eq 'Incorrect'
+      expect(flash[:success]).to eq nil
     end
   end
 end


### PR DESCRIPTION
- #20 の実装
- 解答ページのurlも `/quiz` にした
  - `/quiz/:question_id` にして show 的な感じにしようかと思ったが、question_idがばれないほうがいいかなと思った
  - どうせ解答後しか見れないページなので、質問ページとURL分けなくてもいいかなと思った